### PR TITLE
callouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ formdt README.md --line-length 120
 
 ### Jupyter Notebooks
 
+> [!note] You must specify either `-m` (all markdown cells) or
+> `-c` (specific cells) when formatting notebooks.
+
 ```bash
 # Format all markdown cells
 formdt notebook.ipynb -m -w
@@ -38,8 +41,6 @@ formdt notebook.ipynb -c "1-3,7" -w
 # Preview without writing
 formdt notebook.ipynb -m -l 65
 ```
-
-**Note:** You must specify either `-m` (all markdown cells) or `-c` (specific cells) when formatting notebooks.
 
 ### Library
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -75,3 +75,32 @@ class TestLineWrapping:
         result = format_markdown(text)
 
         assert result == "Short text"
+
+
+class TestCallouts:
+    def test_wraps_callout_with_prefix_on_continuation_lines(self):
+        config = Config(line_length=40)
+        text = "> You must specify either `-m` (all markdown cells) or `-c` (specific cells) when formatting notebooks."
+        result = format_markdown(text, config)
+
+        lines = result.split("\n")
+        assert len(lines) > 1
+        for line in lines:
+            assert line.startswith(">")
+            assert len(line) <= 40
+
+    def test_preserves_short_callout(self):
+        config = Config(line_length=80)
+        text = "> Short callout."
+        result = format_markdown(text, config)
+
+        assert result == "> Short callout."
+
+    def test_nested_callout_prefix_preserved(self):
+        config = Config(line_length=30)
+        text = ">> This is a nested callout that should wrap properly."
+        result = format_markdown(text, config)
+
+        lines = result.split("\n")
+        for line in lines:
+            assert line.startswith(">>")

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "formdt"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "ruff" },


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `formdt` package version and enhancing the `format_markdown` function to properly handle callouts in markdown text. It also introduces tests to ensure the correct formatting of callouts.

### Detailed summary
- Updated `formdt` package version from `0.3.0` to `0.3.1`.
- Added notes in `README.md` regarding formatting options for Jupyter Notebooks.
- Introduced `TestCallouts` class in `tests/test_formatter.py` with tests for callout formatting.
- Enhanced `format_markdown` in `formdt/formatter.py` to handle callout prefixes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->