### PR TITLE
admonition  bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ formdt README.md --line-length 120
 
 ### Jupyter Notebooks
 
-> [!note] You must specify either `-m` (all markdown cells) or
-> `-c` (specific cells) when formatting notebooks.
+> [!note] 
+> You must specify either `-m` (all markdown cells) or `-c`
+> (specific cells) when formatting notebooks.
 
 ```bash
 # Format all markdown cells

--- a/formdt/formatter.py
+++ b/formdt/formatter.py
@@ -8,6 +8,7 @@ HEADING_PATTERN = re.compile(r"^#{1,6}\s")
 CODE_FENCE_PATTERN = re.compile(r"^```")
 MATH_BLOCK_PATTERN = re.compile(r"^\$\$")
 CALLOUT_PATTERN = re.compile(r"^(>+)\s?")
+ADMONITION_PATTERN = re.compile(r"^(>+)\s*\[!(\w+)\]")
 
 
 def format_markdown(text: str, config: Config | None = None) -> str:
@@ -48,6 +49,12 @@ def format_markdown(text: str, config: Config | None = None) -> str:
             or LIST_PATTERN.match(line)
             or line.strip() == ""
         ):
+            result.append(line)
+            i += 1
+            continue
+
+        admonition_match = ADMONITION_PATTERN.match(line)
+        if admonition_match:
             result.append(line)
             i += 1
             continue

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -104,3 +104,21 @@ class TestCallouts:
         lines = result.split("\n")
         for line in lines:
             assert line.startswith(">>")
+
+    def test_github_admonition_stays_on_own_line(self):
+        config = Config(line_length=80)
+        text = "> [!note]\n> You must specify either `-m` (all markdown cells) or `-c` (specific cells) when formatting notebooks."
+        result = format_markdown(text, config)
+
+        lines = result.split("\n")
+        assert lines[0] == "> [!note]"
+        assert all(line.startswith(">") for line in lines)
+
+    def test_github_admonition_with_text_on_same_line(self):
+        config = Config(line_length=80)
+        text = "> [!warning] This is a warning that should stay on its own line.\n> More content here."
+        result = format_markdown(text, config)
+
+        lines = result.split("\n")
+        assert lines[0].startswith("> [!warning]")
+        assert "[!warning]" not in lines[1]


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the formatting of Jupyter notebook markdown cells by adding support for admonitions and introducing tests to ensure proper handling of these elements.

### Detailed summary
- Updated `README.md` to clarify formatting requirements for notebooks.
- Added `ADMONITION_PATTERN` regex in `formdt/formatter.py` to match admonition syntax.
- Modified `format_markdown` function to handle admonitions.
- Added tests in `tests/test_formatter.py` for admonition formatting.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->