### PR TITLE
dont edit previews

### DIFF
--- a/.formdt
+++ b/.formdt
@@ -1,3 +1,3 @@
 {
-    "line_length": 65
+    "line_length": 88
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,10 +32,18 @@ uv run formdt <file> [options]
 
 ## Key Conventions
 
-- Links `[text](url)` are treated as atomic tokens and never broken across lines
+- Links `[text](url)` and images `![alt](url)` are treated as atomic tokens and never broken across lines
 - Default line length is 80 characters
 - Config file is `.formdt` in working directory with `line_length = N` format
 - Notebooks use 0-indexed cell numbers
+
+## Development Approach
+
+We follow test-driven development (TDD):
+1. Write a test that catches the specific functionality or bug we want to fix
+2. Verify the test fails (to confirm we're actually catching the issue)
+3. Implement the fix to make the test pass
+4. Ensure all existing tests still pass
 
 ## Release Process
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ formdt README.md --line-length 120
 ### Jupyter Notebooks
 
 > [!note] 
-> You must specify either `-m` (all markdown cells) or `-c`
-> (specific cells) when formatting notebooks.
+> You must specify either `-m` (all markdown cells) or `-c` (specific cells) when
+> formatting notebooks.
 
 ```bash
 # Format all markdown cells
@@ -72,14 +72,12 @@ Create a `.formdt` file in your project root:
 ## Rules
 
 - **Line wrapping**: Lines are wrapped at the configured length
-(default: 80)
-- **Single line breaks**: Joined within paragraphs (markdown
-treats them as spaces)
+- **Single line breaks**: Joined within paragraphs
 - **Double line breaks**: Preserved as paragraph separators
-- **Links**: ` [text](url) ` patterns are kept intact and never
-broken across lines
-- **Preserved blocks**: Headings, lists, code fences, and math
-blocks (`$$`) are not modified
+- **Links**: ` [text](url) ` patterns are kept intact and never broken across lines
+  - **Previews**: Previews are also kept intact and never broken across lines
+- **Preserved blocks**: Headings, lists, code fences, and math blocks (`$$`) are not
+  modified
 
 ## Development
 
@@ -102,7 +100,8 @@ pytest
 ### sync
 
 ```bash
-uv sync
+uv sync --all-extras
+uv pip install -e .
 ```
 
 ### cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "formdt"
-version = "0.5.0"
-description = "Markdown formatter with configurable line length"
+version = "0.6.0"
+description = "An opinionated markdown formatter"
 readme = "README.md"
 requires-python = ">=3.13"
 

--- a/src/formdt/formatter.py
+++ b/src/formdt/formatter.py
@@ -2,7 +2,7 @@ import re
 
 from .config import Config
 
-LINK_PATTERN = re.compile(r"\[([^\]]*)\]\(([^)]+)\)")
+LINK_PATTERN = re.compile(r"!?\[([^\]]*)\]\(([^)]+)\)")
 INLINE_MATH_PATTERN = re.compile(r"\$\$[^\$]+\$\$")
 LIST_PATTERN = re.compile(r"^(\s*)([-*+]|\d+\.)\s")
 HEADING_PATTERN = re.compile(r"^#{1,6}\s")

--- a/test_image.md
+++ b/test_image.md
@@ -1,0 +1,1 @@
+![Tests Passing](https://github.com/sanchitram1/pyspam/actions/workflows/ci.yml/badge.svg)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -201,3 +201,27 @@ class TestMathBlocks:
 
         # Both $$ should be on the same line (opening and closing)
         assert opening_line == closing_line, "Display math block was split across lines"
+
+
+class TestImageMarkdown:
+    def test_image_markdown_not_split_across_lines(self):
+        config = Config(line_length=88)
+        text = "![Tests Passing](https://github.com/sanchitram1/pyspam/actions/workflows/ci.yml/badge.svg)"
+        result = format_markdown(text, config)
+
+        # Image markdown should not be split - the ! should not be on its own line
+        lines = result.split("\n")
+        assert len(lines) == 1
+        assert result == text
+
+    def test_image_markdown_with_surrounding_text(self):
+        config = Config(line_length=50)
+        text = "See this ![alt](https://example.com/image.png) for details."
+        result = format_markdown(text, config)
+
+        # Image markdown should be kept as atomic token
+        assert "![alt](https://example.com/image.png)" in result
+        # Verify ! is not on its own line
+        lines = result.split("\n")
+        for line in lines:
+            assert line != "!"

--- a/uv.lock
+++ b/uv.lock
@@ -144,7 +144,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf57
 
 [[package]]
 name = "formdt"
-version = "0.4.0"
+version = "0.6.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `formdt` package to enhance its functionality, specifically regarding line length configuration and handling of image markdown. Additionally, it introduces new tests and refines documentation.

### Detailed summary
- Updated `line_length` in `.formdt` from 65 to 88.
- Changed `version` in `uv.lock` and `pyproject.toml` from 0.5.0/0.4.0 to 0.6.0.
- Modified `LINK_PATTERN` in `src/formdt/formatter.py` to support image markdown.
- Updated AGENTS.md to reflect new handling of images as atomic tokens.
- Added a development approach section in AGENTS.md.
- Introduced `TestImageMarkdown` class with tests for image markdown in `tests/test_formatter.py`.
- Enhanced README.md with clearer formatting rules and installation instructions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->